### PR TITLE
Initial SPI data transfer

### DIFF
--- a/src/arduino-src/arduino-src.ino
+++ b/src/arduino-src/arduino-src.ino
@@ -18,6 +18,7 @@ int output_end; /* Store here when reading pins */
 unsigned long output[64][2];
 
 
+
 uint8_t prevpinval = PIND & bitMask;
 uint8_t pinval;
 uint8_t xorpins;
@@ -27,7 +28,7 @@ unsigned long time_elapsed;
 /* ======================== SPI Variables ======================== */
 unsigned char hello[] = {'H','e','l','l','o',' ',
 						 'R','a','s','p','i','\n'};
-byte marker = 0;
+byte marker = 0; /* Index into `long` timestamp in output array */
 
 uint8_t tmp_state           = 123;
 unsigned long tmp_timestamp = 123456789;
@@ -43,6 +44,7 @@ void setup (void) {
 
     /* PIN_D Setup - Sets all D pins to input; may be unnecessary */
     DDRD = 0B00000000;
+    output[0][1] = 0xff00ff00;
 }
 
 /***************************************************************
@@ -57,10 +59,11 @@ void loop (void){
   /* SPI TRANSFER */
 	if((SPSR & (1 << SPIF)) != 0){
 //		SPDR = hello[marker];
-    SPDR = tmp_state;
-		marker++;
+//    SPDR = tmp_state;
+    SPDR = output[0][1] >> marker;
+		marker+=8;
 
-		if(marker > sizeof(hello)){
+		if(marker > 24){
 			marker = 0;
 		}
 	}
@@ -68,21 +71,21 @@ void loop (void){
 
   /* Read PIN_D values */
   // reads high or low value of register at once
-  pinval = PIND & bitMask;
-  xorpins = (prevpinval ^ pinval);
-  
-  // recreates the functionality of the micors() function
-  // without the overhead of a function call
-  time_elapsed = ((timer0_overflow_count << 8) + TCNT0) * 4;
-  
-  if (xorpins != 0) {
-    // stores high pins and timestamp
-    output[i][0] = (pinval >> 3);
-    output[i][1] = time_elapsed;
-    
-    count++;
-  }
-  prevpinval = pinval;
+//  pinval = PIND & bitMask;
+//  xorpins = (prevpinval ^ pinval);
+//  
+//  // recreates the functionality of the micors() function
+//  // without the overhead of a function call
+//  time_elapsed = ((timer0_overflow_count << 8) + TCNT0) * 4;
+//  
+//  if (xorpins != 0) {
+//    // stores high pins and timestamp
+//    output[output_end][0] = (pinval >> 3);
+//    output[output_end][1] = time_elapsed;
+//    
+//    output_end++;
+//  }
+//  prevpinval = pinval;
 
 }
 /******************************************************************************/

--- a/src/arduino-src/arduino-src.ino
+++ b/src/arduino-src/arduino-src.ino
@@ -1,0 +1,103 @@
+/*******************************************************************************
+Crab Tracker - Arduino Code
+
+Reads in data from the pins (attached to Hydrophones) and transfers that data
+via SPI to another device.
+*******************************************************************************/
+
+/* ======================= PIN_D Variables ======================= */
+// Masks off digital pins 0, 1, and 2.
+// Most significant bit of register corresponds to digital pin 7
+uint8_t bitMask = B11111000;
+int output_start; /* Read out for SPI */
+int output_end; /* Store here when reading pins */
+
+/* longs are 32 bits, so the array can only hold 210 values
+   will likely need to hold fewer values when SPI code is
+   integrated in to the code */
+unsigned long output[64][2];
+
+
+uint8_t prevpinval = PIND & bitMask;
+uint8_t pinval;
+uint8_t xorpins;
+extern volatile unsigned long timer0_overflow_count;
+unsigned long time_elapsed;
+
+/* ======================== SPI Variables ======================== */
+unsigned char hello[] = {'H','e','l','l','o',' ',
+						 'R','a','s','p','i','\n'};
+byte marker = 0;
+
+uint8_t tmp_state           = 123;
+unsigned long tmp_timestamp = 123456789;
+
+/***************************************************************
+ Setup SPI in slave mode (1) define MISO pin as output (2) set
+ enable bit of the SPI configuration register
+****************************************************************/
+void setup (void) {
+    /* SPI Setup - Sets pin mode on MISO and does...? */
+	pinMode(MISO, OUTPUT);
+	SPCR |= _BV(SPE);
+
+    /* PIN_D Setup - Sets all D pins to input; may be unnecessary */
+    DDRD = 0B00000000;
+}
+
+/***************************************************************
+ Loop until the SPI End of Transmission Flag (SPIF) is set
+ indicating a byte has been received.  When a byte is
+ received, load the next byte in the Hello[] array into SPDR
+ to be transmitted to the Raspberry Pi, and increment the marker.
+ If the end of the Hell0[] array has been reached, reset
+ marker to 0.
+****************************************************************/
+void loop (void){
+  /* SPI TRANSFER */
+	if((SPSR & (1 << SPIF)) != 0){
+//		SPDR = hello[marker];
+    SPDR = tmp_state;
+		marker++;
+
+		if(marker > sizeof(hello)){
+			marker = 0;
+		}
+	}
+
+
+  /* Read PIN_D values */
+  // reads high or low value of register at once
+  pinval = PIND & bitMask;
+  xorpins = (prevpinval ^ pinval);
+  
+  // recreates the functionality of the micors() function
+  // without the overhead of a function call
+  time_elapsed = ((timer0_overflow_count << 8) + TCNT0) * 4;
+  
+  if (xorpins != 0) {
+    // stores high pins and timestamp
+    output[i][0] = (pinval >> 3);
+    output[i][1] = time_elapsed;
+    
+    count++;
+  }
+  prevpinval = pinval;
+
+}
+/******************************************************************************/
+/*
+*
+*
+* Hydrophones a,b,c, d will correspond to pins 3,4,5,6, respectively.
+*  Digital pin 7 corresponds to the duration indicator.
+*
+*/
+
+
+
+// int i = 0;
+// void loop() {
+//
+//
+// }

--- a/src/pi-src/main.cpp
+++ b/src/pi-src/main.cpp
@@ -54,7 +54,8 @@ int main (void) {
 
     while (1){
         result = spi_getbyte();
-        cout << result;
+        printf("%d\n", result);
+        // cout << result;
         // usleep (10); /* Why 10?? */
         cout << "\nEnter a char to continue\n";
         getchar();

--- a/src/pi-src/main.cpp
+++ b/src/pi-src/main.cpp
@@ -1,0 +1,88 @@
+/**********************************************************
+ SPI_Hello_Arduino
+   Configures an Raspberry Pi as an SPI master and
+   demonstrates bidirectional communication with an
+   Arduino Slave by repeatedly sending the text
+   "Hello Arduino" and receiving a response
+
+Code taken from http://robotics.hobbizine.com/raspiduino.html
+***********************************************************/
+
+#include <sys/ioctl.h>
+#include <linux/spi/spidev.h>
+#include <fcntl.h>
+#include <cstring>
+#include <iostream>
+#include <unistd.h>
+#include <stdio.h>
+using namespace std;
+
+
+/**********************************************************
+Declare Global Variables
+***********************************************************/
+
+int fd;
+unsigned char result;
+
+/**********************************************************
+Declare Functions
+***********************************************************/
+
+int spi_getbyte();
+
+
+/**********************************************************
+Main
+  Setup SPI
+	Open file spidev0.0 (chip enable 0) for read/write
+	  access with the file descriptor "fd"
+	Configure transfer speed (1MkHz)
+  Start an endless loop that repeatedly sends the characters
+	in the hello[] array to the Ardiuno and displays
+	the returned bytes
+***********************************************************/
+int main (void) {
+    fd = open("/dev/spidev0.0", O_RDWR);
+    char buf[1000];
+    /*
+    We need to send an 8-bit state/bitmask, then a 32-bit long timestamp
+     */
+
+    unsigned int speed = 1000000;
+    ioctl (fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed);
+
+    while (1){
+        result = spi_getbyte();
+        cout << result;
+        // usleep (10); /* Why 10?? */
+        cout << "\nEnter a char to continue\n";
+        getchar();
+    }
+}
+
+/**
+ * Grabs one byte via SPI.
+ *
+ * Establishes a data structure, spi_ioc_transfer as defined
+ * by spidev.h and loads the various members to pass the data
+ * and configuration parameters to the SPI device via IOCTL
+ *
+ * Returns a single byte (as in int)
+ */
+int spi_getbyte(){
+    /* Unused, but we have to send SOMETHING. It's the [SPI] rule */
+    unsigned char txDat = ' ';
+    unsigned char rxDat;
+    struct spi_ioc_transfer spi;
+
+    memset (&spi, 0, sizeof (spi));
+
+    spi.tx_buf        = (unsigned long)&txDat;
+    spi.rx_buf        = (unsigned long)&rxDat;
+    spi.len           = 1;
+
+    ioctl (fd, SPI_IOC_MESSAGE(1), &spi);
+
+    return rxDat;
+}

--- a/src/pi-src/main.cpp
+++ b/src/pi-src/main.cpp
@@ -15,26 +15,15 @@ Code taken from http://robotics.hobbizine.com/raspiduino.html
 #include <iostream>
 #include <unistd.h>
 #include <stdio.h>
+#include "spi.h"
 using namespace std;
 
-struct spi_rawblock {
-    unsigned long timestamp;
-    uint8_t pinvals;
-};
 
 /**********************************************************
 Declare Global Variables
 ***********************************************************/
-int fd;
+int spifd;
 unsigned char result;
-
-/**********************************************************
-Declare Functions
-***********************************************************/
-int spi_getbyte();
-int spi_getblock(spi_rawblock*);
-void spi_dispblock(spi_rawblock);
-
 
 /**********************************************************
 Main
@@ -47,82 +36,31 @@ Main
 	the returned bytes
 ***********************************************************/
 int main (void) {
-    fd = open("/dev/spidev0.0", O_RDWR);
+    spifd = open("/dev/spidev0.0", O_RDWR);
     spi_rawblock block;
     /*
     We need to send an 8-bit state/bitmask, then a 32-bit long timestamp
      */
 
     unsigned int speed = 1000000;
-    ioctl (fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed);
+    ioctl (spifd, SPI_IOC_WR_MAX_SPEED_HZ, &speed);
 
     /* For some reason, we get some junk data on the first byte we grab.
         TODO: find out why this happens! Could by SPI thing or could just be
           some dumb thing in the Arduino code I did.
     */
-    spi_getbyte(); /* Throw away the first byte */
+    spi_getbyte(spifd); /* Throw away the first byte. Why is this? */
 
     while (1){
         cout << "Enter a char to get more data via SPI. ";
         getchar();
 
         /* Get and display a block of data from the pi */
-        result = spi_getblock(&block);
+        result = spi_getblock(spifd, &block);
         spi_dispblock(block);
         // result = spi_getbyte();
         // printf("%d\n", result);
         // cout << result;
         // usleep (10); /* Why 10?? */
     }
-}
-
-/**
- * Grabs one byte via SPI.
- *
- * Establishes a data structure, spi_ioc_transfer as defined
- * by spidev.h and loads the various members to pass the data
- * and configuration parameters to the SPI device via IOCTL
- *
- * Returns a single byte (as in int)
- */
-int spi_getbyte(){
-    /* Unused, but we have to send SOMETHING. It's the [SPI] rule */
-    unsigned char txDat = ' ';
-    unsigned char rxDat;
-    struct spi_ioc_transfer spi;
-
-    memset (&spi, 0, sizeof (spi));
-
-    spi.tx_buf        = (unsigned long)&txDat;
-    spi.rx_buf        = (unsigned long)&rxDat;
-    spi.len           = 1;
-
-    ioctl (fd, SPI_IOC_MESSAGE(1), &spi);
-
-    printf(" [raw=0x%x]\n", rxDat);
-    return rxDat;
-}
-
-int spi_getblock(spi_rawblock *data){
-    uint8_t pinvals;
-    unsigned long timestamp = 0;
-
-    /* Get pinvals */
-    pinvals = spi_getbyte();
-
-    /* Get timestamp (in 4 parts) */
-    for(int i=0; i<4; i++){
-        timestamp |= spi_getbyte() << (i * 8);
-        // printf("  timestamp now: 0x%x\n", timestamp);
-    }
-
-    data->pinvals = pinvals;
-    data->timestamp = timestamp;
-    return 1;
-}
-
-void spi_dispblock(spi_rawblock data){
-    printf("--- SPI Raw Data Block ---\n");
-    printf("pinvals: 0x%x\n", data.pinvals);
-    printf("timestamp: 0x%x\n", data.timestamp);
 }

--- a/src/pi-src/makefile
+++ b/src/pi-src/makefile
@@ -1,8 +1,17 @@
-all:
-	@g++ -o crab-tracker main.cpp
+CC=g++
+
+CFILES=main.c spi.c
+OFILES=${CFILES:.c=.o}
+
+all: ${OFILES}
+	$(CC) -o crab-tracker ${OFILES}
 
 run:
 	@./crab-tracker
 
 clean:
-	@rm -rf *.o demo *~
+	@rm -f *.o *~ crab-tracker
+	@echo Working directory cleaned
+
+#dependency list
+${OFILES}: spi.h # add other .h files?

--- a/src/pi-src/makefile
+++ b/src/pi-src/makefile
@@ -1,0 +1,8 @@
+all:
+	@g++ -o crab-tracker main.cpp
+
+run:
+	@./crab-tracker
+
+clean:
+	@rm -rf *.o demo *~

--- a/src/pi-src/spi.cpp
+++ b/src/pi-src/spi.cpp
@@ -1,0 +1,72 @@
+/**********************************************************
+ SPI_Hello_Arduino
+   Configures an Raspberry Pi as an SPI master and
+   demonstrates bidirectional communication with an
+   Arduino Slave by repeatedly sending the text
+   "Hello Arduino" and receiving a response
+
+Code taken from http://robotics.hobbizine.com/raspiduino.html
+***********************************************************/
+
+#include <sys/ioctl.h>
+#include <linux/spi/spidev.h>
+#include <fcntl.h>
+#include <cstring>
+#include <iostream>
+#include <unistd.h>
+#include <stdio.h>
+#include "spi.h"
+using namespace std;
+
+int fd;
+
+/**
+ * Grabs one byte via SPI.
+ *
+ * Establishes a data structure, spi_ioc_transfer as defined
+ * by spidev.h and loads the various members to pass the data
+ * and configuration parameters to the SPI device via IOCTL
+ *
+ * Returns a single byte (as in int)
+ */
+int spi_getbyte(int spifd){
+    /* Unused, but we have to send SOMETHING. It's the [SPI] rule */
+    unsigned char txDat = ' ';
+    unsigned char rxDat;
+    struct spi_ioc_transfer spi;
+
+    memset (&spi, 0, sizeof (spi));
+
+    spi.tx_buf        = (unsigned long)&txDat;
+    spi.rx_buf        = (unsigned long)&rxDat;
+    spi.len           = 1;
+
+    ioctl (spifd, SPI_IOC_MESSAGE(1), &spi);
+
+    printf(" [raw=0x%x]\n", rxDat);
+    return rxDat;
+}
+
+int spi_getblock(int spifd, spi_rawblock *data){
+    uint8_t pinvals;
+    unsigned long timestamp = 0;
+
+    /* Get pinvals */
+    pinvals = spi_getbyte(spifd);
+
+    /* Get timestamp (in 4 parts) */
+    for(int i=0; i<4; i++){
+        timestamp |= spi_getbyte(spifd) << (i * 8);
+        // printf("  timestamp now: 0x%x\n", timestamp);
+    }
+
+    data->pinvals = pinvals;
+    data->timestamp = timestamp;
+    return 1;
+}
+
+void spi_dispblock(spi_rawblock data){
+    printf("--- SPI Raw Data Block ---\n");
+    printf("pinvals: 0x%x\n", data.pinvals);
+    printf("timestamp: 0x%lx\n", data.timestamp);
+}

--- a/src/pi-src/spi.cpp
+++ b/src/pi-src/spi.cpp
@@ -29,12 +29,15 @@ int fd;
  *
  * Returns a single byte (as in int)
  */
-int spi_getbyte(int spifd){
-    /* Unused, but we have to send SOMETHING. It's the [SPI] rule */
-    unsigned char txDat = ' ';
-    unsigned char rxDat;
+uint8_t spi_getbyte(int spifd){
+    uint8_t txDat = 0x0; /* Could be a flag instead */
+    uint8_t rxDat;
     struct spi_ioc_transfer spi;
 
+    /* From /usr/include/linux/spi/spidev.h on the Pi:
+    * "Zero-initialize the structure, including currently unused fields, to
+    * accommodate potential future updates."
+    */
     memset (&spi, 0, sizeof (spi));
 
     spi.tx_buf        = (unsigned long)&txDat;
@@ -43,7 +46,7 @@ int spi_getbyte(int spifd){
 
     ioctl (spifd, SPI_IOC_MESSAGE(1), &spi);
 
-    printf(" [raw=0x%x]\n", rxDat);
+    printf(" [raw=0x%x] (%d bytes)\n", rxDat, sizeof(rxDat));
     return rxDat;
 }
 
@@ -57,7 +60,6 @@ int spi_getblock(int spifd, spi_rawblock *data){
     /* Get timestamp (in 4 parts) */
     for(int i=0; i<4; i++){
         timestamp |= spi_getbyte(spifd) << (i * 8);
-        // printf("  timestamp now: 0x%x\n", timestamp);
     }
 
     data->pinvals = pinvals;

--- a/src/pi-src/spi.h
+++ b/src/pi-src/spi.h
@@ -1,0 +1,13 @@
+/**
+ * SPI Header
+ */
+#include <stdint.h>
+
+struct spi_rawblock {
+    unsigned long timestamp;
+    uint8_t pinvals;
+};
+
+int spi_getbyte(int spifd);
+int spi_getblock(int spifd, spi_rawblock*);
+void spi_dispblock(spi_rawblock);

--- a/src/pi-src/spi.h
+++ b/src/pi-src/spi.h
@@ -3,11 +3,13 @@
  */
 #include <stdint.h>
 
+#define SPI_RESET 0x1
+
 struct spi_rawblock {
     unsigned long timestamp;
     uint8_t pinvals;
 };
 
-int spi_getbyte(int spifd);
+uint8_t spi_getbyte(int spifd);
 int spi_getblock(int spifd, spi_rawblock*);
 void spi_dispblock(spi_rawblock);


### PR DESCRIPTION
Adds the ability to send (fake) data from the Arduino to the pi. The data that is currently sent is fake (placeholder data), but it is in the format of the data that we will send when the pin reading is integrated.

The data is sent via SPI in 8-bit chunks (e.g. the size of a `uint_8t`). The Arduino sends a single 8-bit `int` containing the pin values, and then a 32-bit timestamp. The Pi requests this data in 5 8-byte chunks and reassembles the data on the other end.

Currently, the Pi waits for user input before fetching the next "block" of data. This is to simulate the fact that in the future, the polling may be "random" as the program runs.

This code does not currently read in the values of the pins (i.e. the pulse generator i.e. the hydrophones); this functionality will be added in the future.

When merged, this PR closes #28.