### PR TITLE
Adds UID decoding functions

### DIFF
--- a/src/pi-src/makefile
+++ b/src/pi-src/makefile
@@ -18,7 +18,15 @@ run:
 
 testcode: ${OFILES}
 	$(CXX) -I$(CATCH_PATH) -c test_main.cpp
-	$(CXX) -I$(CATCH_PATH) -o test test_main.o spi.cpp util.cpp ${TESTFILES}
+	$(CXX) -I$(CATCH_PATH) -o test test_main.o spi.cpp util.cpp uid.cpp ${TESTFILES}
+
+test-dc: test_data_collection.cpp data_collection.cpp data_collection.h
+	$(CXX) -I$(CATCH_PATH) -c test_main.cpp
+	$(CXX) -I$(CATCH_PATH) -o test test_main.o spi.cpp util.cpp test_data_collection.cpp
+
+test-uid: test_uid.cpp uid.cpp uid.h
+	$(CXX) -I$(CATCH_PATH) -c test_main.cpp
+	$(CXX) -I$(CATCH_PATH) -o test test_main.o uid.cpp test_uid.cpp
 
 clean:
 	@rm -f *.o *~ crab-tracker test

--- a/src/pi-src/makefile
+++ b/src/pi-src/makefile
@@ -2,8 +2,9 @@ CXX=g++ -std=c++11 -Wall
 # This isn't working: CXXFLAGS=-std=c++11
 CATCH_PATH=`pwd`/include #/catch.hpp
 
-CFILES=main.cpp spi.cpp data_collection.cpp util.cpp
+CFILES=main.cpp spi.cpp data_collection.cpp util.cpp uid.cpp
 OFILES=${CFILES:.c=.o}
+TESTFILES=test_*.cpp
 
 all: ${OFILES}
 	$(CXX) -o crab-tracker ${OFILES}
@@ -16,15 +17,12 @@ run:
 	@./crab-tracker
 
 testcode: ${OFILES}
-	g++ -std=c++11 -Wall -I$(CATCH_PATH) -c test_main.cpp
-	g++ -std=c++11 -Wall -I$(CATCH_PATH) -o test test_main.o test_data_collection.cpp data_collection.cpp spi.cpp util.cpp
-
-test: ${OFILES}
-	@./test
+	$(CXX) -I$(CATCH_PATH) -c test_main.cpp
+	$(CXX) -I$(CATCH_PATH) -o test test_main.o spi.cpp util.cpp ${TESTFILES}
 
 clean:
 	@rm -f *.o *~ crab-tracker test
 	@echo Working directory cleaned
 
 #dependency list
-${OFILES}: spi.h data_collection.h util.h config.h
+${OFILES}: spi.h data_collection.h util.h config.h uid.h

--- a/src/pi-src/test_uid.cpp
+++ b/src/pi-src/test_uid.cpp
@@ -10,33 +10,97 @@ Created: 2018-02-28
 #include "uid.h"
 #include "data_collection.h"
 
+float calc_ping_dur_us(int id){
+    return ((id * STEP_SIZE_MS) + MIN_PING_DUR_MS) * 1000;
+}
+
+float calc_delay_dur_us(int id){
+    return ((id * STEP_SIZE_MS) + MIN_DELAY_DUR_MS) * 1000;
+}
+
 TEST_CASE("UID decoding", "[uid_decoding]"){
 
-    SECTION("PING decoding"){
+    SECTION("Simple PING decoding"){
         int id = 200;
         ping a;
-        long duration = ((id * STEP_SIZE_MS) + MIN_PING_DUR_MS) * 1000;
+        float duration_us = calc_ping_dur_us(id);
 
         a.pin = 0;
         a.start = 0;
-        a.duration = duration;
+        a.duration = duration_us;
 
         REQUIRE(id_decode_ping(a) == id);
     }
 
-    SECTION("DELAY decoding"){
+    SECTION("Simple DELAY decoding"){
         int id = 320;
         int dur = 10;
         ping a, b;
-        long delay = ((id * STEP_SIZE_MS) + MIN_DELAY_DUR_MS) * 1000;
+        float delay = calc_delay_dur_us(id);
 
         a.pin = 0;
         a.start = 0;
         a.duration = dur;
         b.pin = 0;
         b.start = dur + delay;
+
         b.duration = dur;
 
         REQUIRE(id_decode_delay(a, b) == id);
+    }
+
+    /*
+     * Test how the algorithm handles data points that are not perfectly
+     * (mathematically) matched with our expected formula. We expect some
+     * noise or inconsistency in our measurements, so we must be able to
+     * handle this.
+     *
+     * For example, the ping for crab 22 is supposed to be 3.2ms long (by v1
+     * of the iCRAB protocol). However, it's quite likely that it could be
+     * measured as being 3.287ms long.
+     *
+     * We will test a range of values between two IDs to ensure that all
+     * rounding is done as expected.
+     */
+    SECTION("Variance testing - PING"){
+        ping p;
+        int id = 22;
+        float dur;
+        float dur_0 = calc_ping_dur_us(id);
+        float dur_1 = calc_ping_dur_us(id+1);
+        float diff = dur_1-dur_0;
+        p.pin = 0; p.start = 0;
+
+        /* Test up to the midpoint between two durations */
+        for(dur = dur_0; dur < dur_0 + (diff/2); dur++){
+            p.duration = dur;
+            REQUIRE(id_decode_ping(p) == id);
+        }
+        /* Test from the midpoint to the next expected duration */
+        for(; dur <= dur_1; dur++){
+            p.duration = dur;
+            REQUIRE(id_decode_ping(p) == id+1);
+        }
+    }
+    SECTION("Variance testing - DELAY"){
+        ping a, b;
+        int id = 22;
+        float dur;
+        float dur_0 = calc_delay_dur_us(id);
+        float dur_1 = calc_delay_dur_us(id+1);
+        float diff = dur_1-dur_0;
+        a.pin = 0; a.duration = calc_ping_dur_us(id); a.start = 0;
+        b.pin = 0; b.duration = calc_ping_dur_us(id);
+
+        /* Test up to the midpoint between two durations */
+        for(dur = dur_0; dur < dur_0 + (diff/2); dur++){
+            b.start = (a.duration) + dur;
+            REQUIRE(id_decode_delay(a,b) == id);
+        }
+        /* Test from the midpoint to the next expected duration */
+        for(; dur <= dur_1; dur++){
+            b.start = (a.duration) + dur;
+            REQUIRE(id_decode_delay(a,b) == id+1);
+        }
     }
 }

--- a/src/pi-src/test_uid.cpp
+++ b/src/pi-src/test_uid.cpp
@@ -1,0 +1,42 @@
+/******************************************************************************
+Test cases for UID decoding.
+
+Author:  Noah Strong
+Created: 2018-02-28
+******************************************************************************/
+
+#include "catch.hpp"
+
+#include "uid.h"
+#include "data_collection.h"
+
+TEST_CASE("UID decoding", "[uid_decoding]"){
+
+    SECTION("PING decoding"){
+        int id = 205;
+        ping a;
+        long duration = ((id * STEP_SIZE_MS) + MIN_PING_DUR_MS) * 1000;
+
+        a.pin = 0;
+        a.start = 0;
+        a.duration = duration;
+
+        REQUIRE(id_decode_ping(a) == id);
+    }
+
+    SECTION("DELAY decoding"){
+        int id = 320;
+        int dur = 10;
+        ping a, b;
+        long delay = ()(id * STEP_SIZE_MS) + MIN_DELAY_DUR_MS) * 1000;
+
+        a.pin = 0;
+        a.start = 0;
+        a.duration = dur;
+        b.pin = 0;
+        b.start = dur + delay;
+        b.duration = dur;
+
+        REQUIRE(id_decode_delay(a, b) == id);
+    }
+}

--- a/src/pi-src/test_uid.cpp
+++ b/src/pi-src/test_uid.cpp
@@ -13,7 +13,7 @@ Created: 2018-02-28
 TEST_CASE("UID decoding", "[uid_decoding]"){
 
     SECTION("PING decoding"){
-        int id = 205;
+        int id = 200;
         ping a;
         long duration = ((id * STEP_SIZE_MS) + MIN_PING_DUR_MS) * 1000;
 
@@ -28,7 +28,7 @@ TEST_CASE("UID decoding", "[uid_decoding]"){
         int id = 320;
         int dur = 10;
         ping a, b;
-        long delay = ()(id * STEP_SIZE_MS) + MIN_DELAY_DUR_MS) * 1000;
+        long delay = ((id * STEP_SIZE_MS) + MIN_DELAY_DUR_MS) * 1000;
 
         a.pin = 0;
         a.start = 0;

--- a/src/pi-src/uid.cpp
+++ b/src/pi-src/uid.cpp
@@ -20,7 +20,7 @@ Created: 2018-02-28
  */
 int id_decode_ping(ping p){
     long duration_ms = p.duration / 1000; /* convert us->ms */
-    float raw_id = (duration - MIN_PING_DUR_MS) / STEP_SIZE_MS;
+    float raw_id = (duration_ms - MIN_PING_DUR_MS) / STEP_SIZE_MS;
 
     /* TODO: correctly handle variability.
      * for example, do
@@ -43,7 +43,7 @@ int id_decode_ping(ping p){
  */
 int id_decode_delay(ping a, ping b){
     long delay_ms = (b.start - (a.start + a.duration)) / 1000; /* us->ms */
-    float raw_id = (delay - MIN_DELAY_DUR_MS) / STEP_SIZE_MS;
+    float raw_id = (delay_ms - MIN_DELAY_DUR_MS) / STEP_SIZE_MS;
 
     /* TODO: correctly handle variability.
      * for example, do

--- a/src/pi-src/uid.cpp
+++ b/src/pi-src/uid.cpp
@@ -1,11 +1,21 @@
 /******************************************************************************
 Decodes unique identifiers from transmissions
 
+The details of UID encoding and decoding can be found in
+.../doc/TransmissionProtocol/TransmissionProtocol.pdf,
+also known as the iCRAB Protocol Documentation.
+
+Note that we expect some amount of noise or variance in our measured signals,
+so we can't rely on the measured durations or delays matching perfectly with
+our mathematical expectations. To compensate for this, we simply round each
+decoded ID (as a float) to the nearest integer. This way, if a given duration
+is 0.074ms longer than it "should be" based on our documentation, the small
+error is thrown away.
+
 Author:  Noah Strong
 Project: Crab Tracker
 Created: 2018-02-28
 ******************************************************************************/
-
 #include <math.h>
 #include "uid.h"
 

--- a/src/pi-src/uid.cpp
+++ b/src/pi-src/uid.cpp
@@ -1,9 +1,8 @@
 /******************************************************************************
 Decodes unique identifiers from transmissions
 
-The details of UID encoding and decoding can be found in
-.../doc/TransmissionProtocol/TransmissionProtocol.pdf,
-also known as the iCRAB Protocol Documentation.
+The details of UID encoding and decoding can be found in the iCRAB Protocol
+documentation (TransmissionProtocol.pdf).
 
 Note that we expect some amount of noise or variance in our measured signals,
 so we can't rely on the measured durations or delays matching perfectly with

--- a/src/pi-src/uid.cpp
+++ b/src/pi-src/uid.cpp
@@ -19,7 +19,7 @@ Created: 2018-02-28
  * @returns The ID encoded in 'p'
  */
 int id_decode_ping(ping p){
-    long duration = p.duration;
+    long duration_ms = p.duration / 1000; /* convert us->ms */
     float raw_id = (duration - MIN_PING_DUR_MS) / STEP_SIZE_MS;
 
     /* TODO: correctly handle variability.
@@ -42,7 +42,7 @@ int id_decode_ping(ping p){
  * returns The ID encoded by the time between 'a' and 'b'.
  */
 int id_decode_delay(ping a, ping b){
-    long delay = b.start - (a.start + a.duration);
+    long delay_ms = (b.start - (a.start + a.duration)) / 1000; /* us->ms */
     float raw_id = (delay - MIN_DELAY_DUR_MS) / STEP_SIZE_MS;
 
     /* TODO: correctly handle variability.

--- a/src/pi-src/uid.cpp
+++ b/src/pi-src/uid.cpp
@@ -6,6 +6,7 @@ Project: Crab Tracker
 Created: 2018-02-28
 ******************************************************************************/
 
+#include <math.h>
 #include "uid.h"
 
 /**
@@ -19,15 +20,10 @@ Created: 2018-02-28
  * @returns The ID encoded in 'p'
  */
 int id_decode_ping(ping p){
-    long duration_ms = p.duration / 1000; /* convert us->ms */
+    float duration_ms = (float)p.duration / 1000; /* convert us->ms */
     float raw_id = (duration_ms - MIN_PING_DUR_MS) / STEP_SIZE_MS;
 
-    /* TODO: correctly handle variability.
-     * for example, do
-     *   return Math.round(raw_id)
-     * to round up or down appropriately.
-     */
-    return (int)raw_id;
+    return (int)roundf(raw_id);
 }
 
 /**
@@ -42,13 +38,8 @@ int id_decode_ping(ping p){
  * returns The ID encoded by the time between 'a' and 'b'.
  */
 int id_decode_delay(ping a, ping b){
-    long delay_ms = (b.start - (a.start + a.duration)) / 1000; /* us->ms */
+    float delay_ms = ((float)(b.start - (a.start + a.duration))) / 1000; /* us->ms */
     float raw_id = (delay_ms - MIN_DELAY_DUR_MS) / STEP_SIZE_MS;
 
-    /* TODO: correctly handle variability.
-     * for example, do
-     *   return Math.round(raw_id)
-     * to round up or down appropriately.
-     */
-    return (int)raw_id;
+    return (int)roundf(raw_id);
 }

--- a/src/pi-src/uid.cpp
+++ b/src/pi-src/uid.cpp
@@ -1,0 +1,54 @@
+/******************************************************************************
+Decodes unique identifiers from transmissions
+
+Author:  Noah Strong
+Project: Crab Tracker
+Created: 2018-02-28
+******************************************************************************/
+
+#include "uid.h"
+
+/**
+ * Determines the ID encoded in a single ping's duration.
+ *
+ * Will calculate ID based on
+ *     p.duration
+ * while also accounting for slight discrepancies in timing values.
+ *
+ * @param p - The ping to decode
+ * @returns The ID encoded in 'p'
+ */
+int id_decode_ping(ping p){
+    long duration = p.duration;
+    float raw_id = (duration - MIN_PING_DUR_MS) / STEP_SIZE_MS;
+
+    /* TODO: correctly handle variability.
+     * for example, do
+     *   return Math.round(raw_id)
+     * to round up or down appropriately.
+     */
+    return (int)raw_id;
+}
+
+/**
+ * Determines the ID encoded in the delay between two consecutive pings.
+ *
+ * Will calculate ID based on
+ *     b.start - (a.start + a.duration)
+ * while also accounting for slight discrepancies in timing values.
+ *
+ * @param a - The first ping (in chronological order)
+ * @param b - The second ping (in chronological order)
+ * returns The ID encoded by the time between 'a' and 'b'.
+ */
+int id_decode_delay(ping a, ping b){
+    long delay = b.start - (a.start + a.duration);
+    float raw_id = (delay - MIN_DELAY_DUR_MS) / STEP_SIZE_MS;
+
+    /* TODO: correctly handle variability.
+     * for example, do
+     *   return Math.round(raw_id)
+     * to round up or down appropriately.
+     */
+    return (int)raw_id;
+}

--- a/src/pi-src/uid.h
+++ b/src/pi-src/uid.h
@@ -1,9 +1,8 @@
 /******************************************************************************
 Decodes unique identifiers from transmissions
 
-The details of UID encoding and decoding can be found in
-.../doc/TransmissionProtocol/TransmissionProtocol.pdf,
-also known as the iCRAB Protocol Documentation.
+The details of UID encoding and decoding can be found in the iCRAB Protocol
+documentation (TransmissionProtocol.pdf).
 
 Note that we expect some amount of noise or variance in our measured signals,
 so we can't rely on the measured durations or delays matching perfectly with
@@ -23,8 +22,7 @@ Created: 2018-02-28
 #include "data_collection.h"
 
 /*** Transmission Protocol Constants ***
- * Values should match those in
- * .../doc/TransmissionProtocol/TransmissionProtocol.pdf
+ * Values should match those in the TransmissionProtocol.pdf document.
  */
 #define MIN_INTERVAL_S 15
 #define MAX_INTERVAL_S 30

--- a/src/pi-src/uid.h
+++ b/src/pi-src/uid.h
@@ -1,0 +1,28 @@
+/******************************************************************************
+Decodes unique identifiers from transmissions
+
+Author:  Noah Strong
+Project: Crab Tracker
+Created: 2018-02-28
+******************************************************************************/
+
+#ifndef __UID_H
+#define __UID_H
+
+#include "data_collection.h"
+
+/*** Transmission Protocol Constants ***
+ * Values should match those in
+ * .../doc/TransmissionProtocol/TransmissionProtocol.pdf
+ */
+#define MIN_INTERVAL_S 15
+#define MAX_INTERVAL_S 30
+#define MAX_ID 499
+#define MIN_PING_DUR_MS 1.0
+#define MIN_DELAY_DUR_MS 10.0
+#define STEP_SIZE_MS 0.1
+
+int id_decode_ping(ping);
+int id_decode_delay(ping, ping);
+
+#endif /* __UID_H */

--- a/src/pi-src/uid.h
+++ b/src/pi-src/uid.h
@@ -1,6 +1,17 @@
 /******************************************************************************
 Decodes unique identifiers from transmissions
 
+The details of UID encoding and decoding can be found in
+.../doc/TransmissionProtocol/TransmissionProtocol.pdf,
+also known as the iCRAB Protocol Documentation.
+
+Note that we expect some amount of noise or variance in our measured signals,
+so we can't rely on the measured durations or delays matching perfectly with
+our mathematical expectations. To compensate for this, we simply round each
+decoded ID (as a float) to the nearest integer. This way, if a given duration
+is 0.074ms longer than it "should be" based on our documentation, the small
+error is thrown away.
+
 Author:  Noah Strong
 Project: Crab Tracker
 Created: 2018-02-28


### PR DESCRIPTION
Adds two functions for decoding UIDs. They are as follows.

```C++
/**
 * Determines the ID encoded in a single ping's duration.
 *
 * Will calculate ID based on
 *     p.duration
 * while also accounting for slight discrepancies in timing values.
 *
 * @param p - The ping to decode
 * @returns The ID encoded in 'p'
 */
int id_decode_ping(ping p);
```


```C++
/**
 * Determines the ID encoded in the delay between two consecutive pings.
 *
 * Will calculate ID based on
 *     b.start - (a.start + a.duration)
 * while also accounting for slight discrepancies in timing values.
 *
 * @param a - The first ping (in chronological order)
 * @param b - The second ping (in chronological order)
 * returns The ID encoded by the time between 'a' and 'b'.
 */
int id_decode_delay(ping a, ping b);
```

As of this PR, these functions are not used in `main()` so as to avoid merge conflicts with existing work on other branches.

Once merged, this PR closes #14.